### PR TITLE
황지훈/4주차/백준/여행 가자/골드4

### DIFF
--- a/HJH/4주차/boj_1976.java
+++ b/HJH/4주차/boj_1976.java
@@ -1,0 +1,82 @@
+/******************************************************************************
+
+ 문제출처 : https://www.acmicpc.net/problem/1976
+ 풀이시간 : 1h
+ 시간복잡도 : O(n^2 * m)
+ 공간복잡도 : O(n)
+
+ *******************************************************************************/
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    private static int n, m;
+    private static int[][] map;
+    private static int[] path;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        for (int i = 1; i < m; i++) {
+            if (path[i - 1] == path[i]) continue;
+
+            if (!bfs(path[i - 1], path[i])) {
+                System.out.print("NO");
+                return;
+            }
+        }
+
+        System.out.print("YES");
+    }
+
+    private static boolean bfs(int from, int to) {
+        boolean[] visited = new boolean[n + 1];
+        Queue<Integer> Q = new LinkedList<>();
+        Q.add(from);
+        visited[from] = true;
+
+        while (!Q.isEmpty()) {
+            int cur = Q.poll();
+
+            for (int adj = 1; adj <= n; adj++) {
+                if (map[cur][adj] == 0 || visited[adj]) continue;
+
+                if (adj == to) return true;
+
+                Q.add(adj);
+                visited[adj] = true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void init() throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+        m = Integer.parseInt(br.readLine());
+
+        map = new int[n + 1][n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            var st = new StringTokenizer(br.readLine());
+
+            for (int j = 1; j <= n; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        path = new int[m];
+
+        var st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < m; i++) {
+            path[i] = Integer.parseInt(st.nextToken());
+        }
+
+        br.close();
+    }
+
+}

--- a/HJH/4주차/boj_1976.java
+++ b/HJH/4주차/boj_1976.java
@@ -78,5 +78,23 @@ public class Main {
 
         br.close();
     }
+ 
+     /* dfs */
+     private static boolean solve(int cur, int to, boolean[] visited){
+        if(cur == to){
+            return true;
+        }
+        
+        visited[cur] = true;
+        
+        for(int adj = 1; adj <= n; adj++){
+            if(map[cur][adj] == 0 || visited[adj]) continue;
+            
+            visited[adj] = true;
+            if(solve(adj, to, visited)) return true;
+        }
+        
+        return false;
+    }
 
 }

--- a/HJH/4주차/boj_20207.java
+++ b/HJH/4주차/boj_20207.java
@@ -1,0 +1,62 @@
+/******************************************************************************
+
+ 문제출처 : https://www.acmicpc.net/problem/20207
+ 풀이시간 : 30m
+ 시간복잡도 : O(365) 
+ 공간복잡도 : O(n)
+ 
+ *******************************************************************************/
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    private static int n;
+    private static int[] schedules = new int[366 + 1];
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        int result = 0;
+        int start = 0;
+        int high = 0;
+        for (int day = 1; day <= 365 + 1; day++) {
+            if (high < schedules[day]) high = schedules[day];
+
+            if (schedules[day] != 0 && start == 0) {
+                start = day;
+
+                continue;
+            }
+
+            if (schedules[day] == 0 && start != 0) {
+                result += (day - start) * high;
+                start = 0;
+                high = 0;
+            }
+        }
+
+        System.out.print(result);
+    }
+
+    private static void init() throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+
+        for (int i = 1; i <= n; i++) {
+            var st = new StringTokenizer(br.readLine());
+
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            for (int f = from; f <= to; f++) {
+                schedules[f]++;
+            }
+        }
+
+        br.close();
+    }
+
+}

--- a/HJH/4주차/boj_2470.java
+++ b/HJH/4주차/boj_2470.java
@@ -1,0 +1,68 @@
+/******************************************************************************
+
+ 문제출처 : https://www.acmicpc.net/problem/2470
+ 풀이시간 : 1h
+ 시간복잡도 : O(n) 
+ 공간복잡도 : O(n)
+ 
+ *******************************************************************************/
+
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    private static int n;
+    private static int[] inputs;
+    private static int pick1, pick2;
+
+    public static void main(String[] args) throws IOException {
+        init();
+
+        solve();
+
+        System.out.print(pick1 + " " + pick2);
+    }
+
+    private static void solve() {
+        int low = 0;
+        int high = n - 1;
+        int minSum = Integer.MAX_VALUE;
+
+        while (low < high) {
+            int sum = inputs[low] + inputs[high];
+
+            if (Math.abs(sum) < minSum) {
+                minSum = Math.abs(sum);
+
+                pick1 = inputs[low];
+                pick2 = inputs[high];
+            }
+
+            if (sum > 0) {
+                high--;
+            } else {
+                low++;
+            }
+        }
+    }
+
+    private static void init() throws IOException {
+        var br = new BufferedReader(new InputStreamReader(System.in));
+
+        n = Integer.parseInt(br.readLine());
+
+        inputs = new int[n];
+
+        var st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < n; i++) {
+            inputs[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(inputs);
+
+        br.close();
+    }
+
+}


### PR DESCRIPTION
## 1.시간복잡도
- O(n^2 * m) = O(200^2 * 1,000) = O(40,000 * 1,000) = O(40,000,000) < 1억. 따라서 1초 미만
- bfs를 이용했기 때문에 기본적으로 bfs의 시간복잡도인 n^2에서 모든 경로의 원소마다 bfs를 진행하니 m을 곱해줬습니다.
- n은 전체 노드의 개수이고 m은 경로 상 노드의 개수입니다.

## 2.알고리즘 설명
- 경로 상 인접하는 두 노드를 대상으로 bfs를 돌려줬습니다.
- disjoint set 으로도 문제를 해결할 수 있을 거 같아요 (추후진행예정)

## 3. 얻어갈 점
- 크게 없음

## 4. 실패
- disjoint set으로 풀어보고 있으나 알고리즘 이해가 필요해 보임

#### 문제링크 : https://www.acmicpc.net/problem/1976